### PR TITLE
Enable postBuild support for rocker image

### DIFF
--- a/repo2docker_wholetale/rocker.py
+++ b/repo2docker_wholetale/rocker.py
@@ -252,5 +252,6 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
             build_script_files=build_script_files,
             build_scripts=self.get_build_scripts(),
             build_script_directives=build_script_directives,
+            post_build_scripts=self.get_post_build_scripts(),
             start_script="/start.sh",
         )

--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -81,6 +81,12 @@ class WholeTaleBuildPack(BuildPack):
         if os.path.exists(installR_path):
             return ("${NB_USER}", "Rscript %s" % installR_path)
 
+    def get_post_build_scripts(self):
+        post_build = self.binder_path("postBuild")
+        if os.path.exists(post_build):
+            return [post_build]
+        return []
+
     def descriptionR_assemble_script(self):
         description_R = 'DESCRIPTION'
         if not self.binder_dir and os.path.exists(description_R):


### PR DESCRIPTION
We weren't passing `post_build_scripts` keyword for Rocker template. This PR fixes that.

### How to test?
1. Create Tale with RStudio image
1. Add postBuild
1. Check if postBuild was run in the build log

Alternative:
```
mkdir /tmp/my_tale
cat <<- EOF > /tmp/my_tale/environment.json
  {"config": {"buildpack": "RockerBuildPack"}}
EOF
touch /tmp/my_tale/postBuild
repo2docker --config <path_to_r2d_wt>/repo2docker_wholetale/repo2docker_config.py \
   --user-name rstudio --user-id 1000 --debug --no-build \
   /tmp/my_tale 2>&1 | grep 'RUN ./postBuild'
```