### PR TITLE
Change base buildpack to R to help with Python+R composability

### DIFF
--- a/repo2docker_wholetale/jupyter.py
+++ b/repo2docker_wholetale/jupyter.py
@@ -5,11 +5,11 @@
 import json
 import os
 
-from repo2docker.buildpacks.python import PythonBuildPack
+from repo2docker.buildpacks.r import RBuildPack
 
 
-class JupyterWTStackBuildPack(PythonBuildPack):
-    def detect(self, buildpack="PythonBuildPack"):
+class JupyterWTStackBuildPack(RBuildPack):
+    def detect(self, buildpack="RBuildPack"):
         if not os.path.exists(self.binder_path("environment.json")):
             return False
 


### PR DESCRIPTION
As noted in https://github.com/whole-tale/repo2docker_wholetale/issues/6, we currently can't support Jupyter environments that rely on R. This is also the case with the new Spark+R tale use case.

This seems to be the simplest approach to fix the problem for v0.9.

To confirm, test that the "Dataverse IRC Metrics" example actually works, or just create a new Jupyter tale that needs R.