### PR TITLE
Fixed environment.json buildpack name

### DIFF
--- a/repo2docker_wholetale/jupyter.py
+++ b/repo2docker_wholetale/jupyter.py
@@ -9,7 +9,7 @@ from repo2docker.buildpacks.r import RBuildPack
 
 
 class JupyterWTStackBuildPack(RBuildPack):
-    def detect(self, buildpack="RBuildPack"):
+    def detect(self, buildpack="PythonBuildPack"):
         if not os.path.exists(self.binder_path("environment.json")):
             return False
 


### PR DESCRIPTION
Fixes problem I introduced when changing the base class.  