### PR TITLE
Allow to configure Rocker base image and RStudio download url. Fixes #12

### DIFF
--- a/repo2docker_wholetale/rocker.py
+++ b/repo2docker_wholetale/rocker.py
@@ -23,18 +23,18 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
         apt-get -qq purge && \
         apt-get -qq clean && \
         rm -rf /var/lib/apt/lists/*
-        
+
         # Use bash as default shell, rather than sh
         ENV SHELL /bin/bash
 
         # Set up user and repo_dir (not used in this template)
-        ARG NB_USER
-        ARG NB_UID
-        ARG USER
+        ARG NB_USER=rstudio
+        ARG NB_UID=1000
+        ARG USER=rstudio
         ENV NB_USER=rstudio
         ENV NB_UID=1000
-        # USER required for --auth-none 1 
-        ENV USER=rstudio 
+        # USER required for --auth-none 1
+        ENV USER=rstudio
 
         EXPOSE 8787
 
@@ -74,7 +74,7 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
         # The XDG standard suggests ~/.local/bin as the path for local user-specific
         # installs. See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
         ENV PATH ${HOME}/.local/bin:${REPO_DIR}/.local/bin:${PATH}
-        
+
         USER root
         # Copy cwd, to get aux files, it's going to be overshadowed with WT mount
         COPY src/ ${REPO_DIR}
@@ -141,8 +141,10 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
             return False
 
     def get_build_scripts(self):
-        rstudio_url = 'http://use.yt/upload/e66cd310'
-        rstudio_checksum = 'e9764a5246bccc5ff9e39b62aea148ff'
+        rstudio_url = self.wt_env.get("WT_RSTUDIO_URL", "http://use.yt/upload/e66cd310")
+        rstudio_checksum = self.wt_env.get(
+            "WT_RSTUDIO_MD5", "e9764a5246bccc5ff9e39b62aea148ff"
+        )
 
         scripts = [
             (
@@ -243,7 +245,7 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
         }
 
         return t.render(
-            image_spec='3.5.1',  # TODO: fixme
+            image_spec=self.wt_env.get("WT_ROCKER_VER", "3.5.1"),
             files=files,
             labels={},
             path=self.get_path(),

--- a/repo2docker_wholetale/rocker.py
+++ b/repo2docker_wholetale/rocker.py
@@ -141,7 +141,13 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
             return False
 
     def get_build_scripts(self):
-        rstudio_url = self.wt_env.get("WT_RSTUDIO_URL", "http://use.yt/upload/e66cd310")
+        rstudio_url = self.wt_env.get(
+            "WT_RSTUDIO_URL",
+            (
+                "https://github.com/whole-tale/rstudio/releases/download/"
+                "v1.2.679-wt/rstudio-server-1.2.679-debian9-x86_64.deb"
+            ),
+        )
         rstudio_checksum = self.wt_env.get(
             "WT_RSTUDIO_MD5", "e9764a5246bccc5ff9e39b62aea148ff"
         )


### PR DESCRIPTION
### How to test

1. Checkout this branch and deploy locally (`pip install -e .`)
1. `mkdir -p /tmp/blah && cd /tmp/blah`
1. Run:
    ```
    cat <<- EOF > /tmp/blah/environment.json
    {
    	"config": {
    		"buildpack": "RockerBuildPack",
    		"command": "/start.sh",
    		"environment": [
    			"CSP_HOSTS=https://dashboard.wholetale.org",
    			"PASSWORD=password"
    		],
    		"memLimit": "2048m",
    		"port": 8787,
    		"targetMount": "/WholeTale/",
    		"urlPath": "",
    		"user": "rstudio"
    	},
    	"icon": "https://www.rstudio.com/wp-content/uploads/2014/06/RStudio-Ball.png",
    	"iframe": true,
    	"name": "RStudio",
    	"public": true,
    	"tags": [
    		"latest"
    	]
    }
    EOF
    ```
1. `repo2docker --config <path_to>/whole-tale/repo2docker_wholetale/repo2docker_config.py --user-name rstudio --user-id 1000 --no-run .` which will output image name e.g. `Successfully tagged r2d-2e1600880746:latest`
1. Using the image from previous step run `docker run -p 8787:8787 -ti -e PASSWORD=password r2d-2e1600880746:latest /start.sh`
1. Go to http://localhost:8787/ and make sure that:
    * it runs R 3.5.1 (blurb in the left panel)
    * it runs RStudio 1.2.679 (Help > About RStudio)
    * File pane has WT icon in breadcrumbs
1. Stop your container
1. Modify `environment.json` by adding:
    ```
          "WT_ROCKER_VER=4.0.2",
          "WT_RSTUDIO_URL=http://use.yt/upload/dbda6b23",
          "WT_RSTUDIO_MD5=805e9a4657b294300f8d427e144c3c6d",
    ```
    to the `config.environment` section (be mindful that the last entry in JSON array cannot end with `,`)
1. Repeat 4. and 5. (use new image in 5.)
1. Go to http://localhost:8787/ and make sure that:
    * it runs R 4.0.2 (blurb in the left panel)
    * it runs RStudio 1.3.1093 (Help > About RStudio)
    * File pane has WT icon in breadcrumbs
