### PR TITLE
Adds MATLAB Web Desktop support

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -36,7 +36,9 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
     def get_build_env(self):
         # MLM_LICENSE_FILE specifies the path to the license at runtime
         return super().get_build_env() + [
-            ("MLM_LICENSE_FILE", "/licenses/matlab/network.lic")
+            ("MLM_LICENSE_FILE", "/licenses/matlab/network.lic"),
+            ("BASE_URL", "/matlab"),
+            ("APP_PORT", "8888")
         ]
 
     def get_path(self):
@@ -81,17 +83,17 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 ),
             ),
             (
+                "${NB_USER}",
+                r"""
+                ${NB_PYTHON_PREFIX}/bin/pip install matlab_kernel https://github.com/mathworks/jupyter-matlab-proxy/archive/0.1.0.tar.gz
+                """,
+            ),
+            (
                 "root",
                 r"""
                 cd /usr/local/MATLAB/*/extern/engines/python && python setup.py install
                 """,
-            ),
-            (
-                "${NB_USER}",
-                r"""
-                ${NB_PYTHON_PREFIX}/bin/pip install matlab_kernel
-                """,
-            ),
+            )
         ]
 
     def get_preassemble_scripts(self):
@@ -139,6 +141,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
         return {
             "apt-transport-https",
             "ca-certificates",
+            "curl",
             "dbus-x11",
             "gnupg",
             "lsb-release",
@@ -157,6 +160,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             "libgssapi-krb5-2",
             "libgstreamer-plugins-base1.0-0",
             "libgstreamer1.0-0",
+            "libglib2.0-0",
             "libgtk2.0-0",
             "libk5crypto3",
             "libkrb5-3",
@@ -190,6 +194,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             "libxtst6",
             "libxxf86vm1",
             "procps",
+            "python3-pip",
             "python-websockify",
             "software-properties-common",
             "wget",


### PR DESCRIPTION
This PR adds the MATLAB Web Desktop IDE support.  Note that MATLAB now has "Live Scripts" which are their version of notebooks.  The IDE is intended to replicate the MATLAB Desktop IDE for the web with the same functionality starting with R2020b. Versions prior to R2020b will either need to use JupyterLab with MATLAB Kernel or XPRA.

**Requires:**
* https://github.com/whole-tale/deploy-dev/pull/39 (updated)
* https://github.com/whole-tale/gwvolman/pull/127

**To Test:**
* Follow https://github.com/whole-tale/deploy-dev/pull/39 to setup environment and create base image
* Create a new Tale selecting the "MATLAB (Desktop)" environment
* Run the tale and confirm the Web Desktop IDE displays in both iFrame and non-iFrame modes
* Optionally, upload the `toolboxes.txt` and `multiplicative_arima_example.mlx` from https://github.com/craig-willis/matlab-example, rebuild/restart the Tale and confirm that you can run the live script.

**Brief demo videos:**

Live Script example:

https://user-images.githubusercontent.com/4334350/104517222-a5963380-55c3-11eb-88ba-ad67e37abb88.mov

Just a normal MATLAB script:

https://user-images.githubusercontent.com/4334350/104515206-7b8f4200-55c0-11eb-8b57-9971b82d0dad.mov


