### PR TITLE
Stop using xpra beta repo

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -65,7 +65,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 "root",
                 r"""
                 wget -q https://xpra.org/gpg.asc -O- | apt-key add - && \
-                add-apt-repository "deb https://xpra.org/beta bionic main" && \
+                add-apt-repository "deb https://xpra.org/ bionic main" && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y  xpra xpra-html5
                 """,
             ),

--- a/repo2docker_wholetale/stata.py
+++ b/repo2docker_wholetale/stata.py
@@ -45,7 +45,7 @@ class StataWTStackBuildPack(JupyterWTStackBuildPack):
                 "root",
                 r"""
                 wget -q https://xpra.org/gpg.asc -O- | apt-key add - && \
-                add-apt-repository "deb https://xpra.org/beta bionic main" && \
+                add-apt-repository "deb https://xpra.org/ bionic main" && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y  xpra xpra-html5
                 """
             ),


### PR DESCRIPTION
Grr.  I started using the xpra `beta` channel because the `xpra-html5` client install was failing on stable.  Now the `xpra-html5` package is failing on beta. 

To test:  build a Stata or Matlab image and it should succeed.
