### PR TITLE
Upgrade Mathworks plugin to v0.2

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -85,7 +85,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             (
                 "${NB_USER}",
                 r"""
-                ${NB_PYTHON_PREFIX}/bin/pip install matlab_kernel https://github.com/mathworks/jupyter-matlab-proxy/archive/0.1.0.tar.gz
+                ${NB_PYTHON_PREFIX}/bin/pip install matlab_kernel https://github.com/mathworks/jupyter-matlab-proxy/archive/v0.2.0.tar.gz
                 """,
             ),
             (


### PR DESCRIPTION
Mathworks releases v0.2 in May https://github.com/mathworks/jupyter-matlab-proxy/releases

Running this on my dev instance I don't see the problems I'm experiencing on production.

Note that v0.3.x was released this week but I haven't tested locally.