### PR TITLE
Make MATLAB proxy version configurable on image

### DIFF
--- a/examples/matlab/environment.json
+++ b/examples/matlab/environment.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "buildpack": "MatlabBuildPack",
+    "command": "matlab-jupyter-app",
+    "csp": "default-src 'self' *.mathworks.com:*; style-src 'self' 'unsafe-inline' *.mathworks.com:*; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.mathworks.com:*; img-src 'self' *.mathworks.com:* data:; frame-ancestors 'self' *.mathworks.com:* dashboard.wholetale.org dashboard.stage.wholetale.org; frame-src 'self' *.mathworks.com:*; connect-src 'self' *.mathworks.com:* wss://localhost:* wss://127.0.0.1:*",
+    "environment": [
+      "VERSION=R2020b",
+      "MWI_BASE_URL=/matlab",
+      "MWI_APP_PORT=8888",
+      "WT_MATLAB_PROXY_VERSION=v0.3.1"
+    ]
+  }
+}

--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -60,6 +60,10 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
         install MATLAB core product. Installs Python engine and
         Jupyter kernel.
         """
+        matlab_proxy_version = self.wt_env.get(
+            "WT_MATLAB_PROXY_VERSION", "v0.3.2"
+        )
+
         return super().get_build_scripts() + [
             (
                 "root",
@@ -85,8 +89,10 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             (
                 "${NB_USER}",
                 r"""
-                ${NB_PYTHON_PREFIX}/bin/pip install matlab_kernel https://github.com/mathworks/jupyter-matlab-proxy/archive/v0.2.0.tar.gz
-                """,
+                ${{NB_PYTHON_PREFIX}}/bin/pip install matlab_kernel jupyter-matlab-proxy=={matlab_proxy_version}
+                """.format(
+                    matlab_proxy_version=matlab_proxy_version
+                ),
             ),
             (
                 "root",


### PR DESCRIPTION
**Problem**:
Mathworks seems to be updating the proxy about every 2-3 months. v0.3.2 introduces two new environment variables that must be set, which I'm now handling via the image object.  I've also introduced the `WT_MATLAB_PROXY_VERSION` env var via `wt_env` to supporting configuring the proxy package version going forward without rebuilding.

```
from girder.plugins.wholetale.models.image import Image
image = Image().findOne({"name": "MATLAB (Desktop) [R2020b]"})
image["config"]["environment"] = ["VERSION=R2020b", "MWI_BASE_URL=/matlab", 
   "MWI_APP_PORT=8888", "WT_MATLAB_PROXY_VERSION=v0.3.2"]
Image().save(image)
```

To test without using WT:
* Checkout and install https://github.com/whole-tale/repo2docker
* Checkout and install this branch (`pip install -e .`)
* `cd repo2docke_wholetale/examples/matlab`
* `repo2docker --config /home/ubuntu/repo2docker_wholetale/repo2docker_config.py --user-name jovyan --user-id 1000 --debug --no-run . 2>&1 | grep jupyter-matlab-proxy`
* Confirm `jupyter-matlab-proxy==v0.3.2`
* Change environment.json version to v0.3.1
* Confirm `jupyter-matlab-proxy==v0.3.1`

To test with WT:
* Build this image and configure in `gwvolman/constants.py` or just use my `craigwillis/repo2docker_wholetale:matlab`
* Create and run a MATLAB desktop tale.
* Confirm that v0.3.2 was installed either by inspecting celery logs or package in-container
* Optionally change `WT_MATLAB_PROXY_VERSION` to `v0.3.1` and re-test. 


