### PR TITLE
Fix broken R buildpack

### DIFF
--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -56,8 +56,8 @@ class WholeTaleBuildPack(BuildPack):
                 "root",
                 r"""
                 wget -O /usr/local/bin/reprozip https://github.com/cirss/reprozip-static/releases/download/v1.0.16-r1/reprozip-1.016-linux-x86-64-static \
-                chmod u+x /usr/local/bin/reprozip \
-                repozip usage_report --disable
+                && chmod a+x /usr/local/bin/reprozip \
+                && reprozip usage_report --disable
                 """
             )
         ]


### PR DESCRIPTION
I don't recall why my reprozip PR was merged to stable (https://github.com/whole-tale/repo2docker_wholetale/commit/1e3a6ceb3c342184d200869e9c80fb627512ab44), but I just noticed that it breaks the WholeTaleRBuildPack.