### PR TITLE
Pip install reprozip into virtual environment

### DIFF
--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -49,19 +49,21 @@ class WholeTaleBuildPack(BuildPack):
         )
         return files
 
-
     def get_build_scripts(self):
+        # Install reprozip and dependencies in venv
         return super().get_build_scripts() + [
             (
                 "root",
                 r"""
-                wget -O /usr/local/bin/reprozip https://github.com/cirss/reprozip-static/releases/download/v1.0.16-r1/reprozip-1.016-linux-x86-64-static \
-                && chmod a+x /usr/local/bin/reprozip \
-                && reprozip usage_report --disable
+                apt-get update -y && \
+                apt-get install -y libsqlite3-dev python3-pip python3-venv python3-wheel && \
+                python3 -m venv /reprozip && \
+                . /reprozip/bin/activate && \
+                python3 -m pip install -U pip setuptools && \
+                pip3 install reprozip==1.0.16
                 """
             )
         ]
-
 
     def apt_assemble_script(self):
         if os.path.exists(self.binder_path("apt.txt")):
@@ -172,13 +174,17 @@ class WholeTaleRBuildPack(RBuildPack):
             return False
 
     def get_build_scripts(self):
+        # Install reprozip and dependencies in venv
         return super().get_build_scripts() + [
             (
                 "root",
                 r"""
-                wget -O /usr/local/bin/reprozip https://github.com/cirss/reprozip-static/releases/download/v1.0.16-r1/reprozip-1.016-linux-x86-64-static \
-                && chmod a+x /usr/local/bin/reprozip \
-                && reprozip usage_report --disable
+                apt-get update -y && \
+                apt-get install -y libsqlite3-dev python3-pip python3-venv python3-wheel && \
+                python3 -m venv /reprozip && \
+                . /reprozip/bin/activate && \
+                python3 -m pip install -U pip setuptools && \
+                pip3 install reprozip==1.0.16
                 """
             )
         ]


### PR DESCRIPTION
**Problem** 
Our current approach using the pyinstaller/static build of reprozip fails in rocker/geospatial images with error (locale.Error: unsupported locale setting).  Instead of trying to maintain a static build of reprozip, we agreed that it makes sense to install into a virtualenv via pip. Unfortunately rocker images also do not have pip/venv installed...  

**Approach**
This PR updates the WholeTaleBuildPack and WholeTaleRBuildPack classes to apt install required dependencies (libsqlite3-dev, python3-pip, python3-venv) then creating a venv and installing reprozip.  

**To Test**
* Create an R tale and build the image. Image build should succeed without the locale error.
* Optionally create and run a recorded run and confirm that reprozip executes as expected.
* Do the same for Jupyter-based tale
