### PR TITLE
Adds XFCE support for MATLAB environments

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -1,11 +1,10 @@
 import os
-import json
 from .jupyter import JupyterWTStackBuildPack
 
 
 class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
     """
-    Setup Matlab for use with a repository
+    Setup Matlab for use with a repository.
 
     This sets up MATLAB, JupyterLab and the
     [matlab-kernel](https://github.com/Calysto/matlab_kernel
@@ -70,7 +69,9 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 r"""
                 wget -q https://xpra.org/gpg.asc -O- | apt-key add - && \
                 add-apt-repository "deb https://xpra.org/ bionic main" && \
-                DEBIAN_FRONTEND=noninteractive apt-get install -y  xpra xpra-html5
+                DEBIAN_FRONTEND=noninteractive apt-get install -y  xpra xpra-html5 && \
+                mkdir -p /run/xpra && chmod 755 /run/xpra && \
+                mkdir -p /run/user/${NB_UID} && chown ${NB_UID} /run/user/${NB_UID} && chmod 700 /run/user/${NB_UID}
                 """,
             ),
             (
@@ -98,6 +99,53 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 "root",
                 r"""
                 cd /usr/local/MATLAB/*/extern/engines/python && python setup.py install
+                """,
+            ),
+            (
+                "root",
+                r"""
+                DEBIAN_FRONTEND=noninteractive apt-get install -y  matlab-support && \
+                chown -R ${NB_USER}:${NB_USER} ${HOME}/.matlab
+                """,
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                mkdir -p ${HOME}/Desktop && \
+                printf "[Desktop Entry]\n\
+                Version=1.0\n\
+                Type=Application\n\
+                Name=MATLAB\n\
+                Comment=\n\
+                Exec=matlab –desktop\n\
+                Icon=matlab\n\
+                Path=${HOME}/work/workspace\n\
+                Terminal=true\n\
+                StartupNotify=false\n"\
+                > ${HOME}/Desktop/MATLAB.desktop && \
+                printf "[Desktop Entry]\n\
+                Version=1.0\n\
+                Type=Application\n\
+                Name=Terminal\n\
+                Comment=\n\
+                Exec=exo-open --launch TerminalEmulator\n\
+                Icon=utilities-terminal\n\
+                Path=${HOME}/work/workspace\n\
+                Terminal=false\n\
+                StartupNotify=false\n"\
+                > ${HOME}/Desktop/Terminal.desktop && \
+                printf "[Desktop Entry]\n\
+                Version=1.0\n\
+                Type=Application\n\
+                Name=Firefox\n\
+                Comment=\n\
+                Exec=firefox %u\n\
+                Icon=firefox\n\
+                Path=\n\
+                Terminal=false\n\
+                StartupNotify=false\n"\
+                > ${HOME}/Desktop/Firefox.desktop && \
+                chmod +x ${HOME}/Desktop/*.desktop
                 """,
             )
         ]
@@ -219,4 +267,8 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             "g++",
             "gfortran",
             "csh",
+            'xubuntu-icon-theme',
+            'firefox',
+            'mousepad',
+            'xfce4',
         }.union(super().get_base_packages())


### PR DESCRIPTION
This PR ports the XFCE and desktop-related changes from the StataBuildPack https://github.com/whole-tale/repo2docker_wholetale/pull/26 to MATLAB

* Setup Xpra run dirs
* Adds xfce, firefox, mousepad as with Stata
* Creates desktop shortcuts
* apt installs `matlab-support` for icons, preferences, etc 

*To Test*

Without WT

* Checkout and install this branch (pip install -e .)
* cd repo2docker_wholetale/examples/matlab
* `repo2docker --build-arg FILE_INSTALLATION_KEY=<matlab key> --config /home/ubuntu/repo2docker_wholetale/repo2docker_config.py --user-name jovyan --user-id 1000 --debug --no-run . `
* `docker run -it -p 10000:10000 <r2d-image> xpra start-desktop --bind-tcp=0.0.0.0:10000 --html=on --daemon=no --exit-with-children=no --start=xfce4-session` 
* Connect to 10000 and confirm that you get an Xpra session with XFCE and desktop icons. You'll need a valid license to actually run Matlab.

To test with WT:
* Build this image and configure in `run_worker.sh`
* Setup Xpra images via https://github.com/whole-tale/deploy-dev/pull/51
* Create and run a MATLAB Linux desktop tale.
* Confirm XFCE desktop and that MATLAB runs as expected.

