### PR TITLE
Various fixes for supporting iframes running in external domains

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+examples

--- a/repo2docker_wholetale/base/jupyter_notebook_config.py
+++ b/repo2docker_wholetale/base/jupyter_notebook_config.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    cookie_options = {"SameSite": None, "Secure": True}
+    c.NotebookApp.tornado_settings = {"xsrf_cookie_kwargs": cookie_options}
+    c.NotebookApp.cookie_options = cookie_options

--- a/repo2docker_wholetale/jupyter.py
+++ b/repo2docker_wholetale/jupyter.py
@@ -27,6 +27,7 @@ class JupyterWTStackBuildPack(WholeTaleRBuildPack):
         files = {}
         for k, v in {
             "base/healthcheck.py": "/healthcheck.py",
+            "base/jupyter_notebook_config.py": "${HOME}/.jupyter/jupyter_notebook_config.py"
         }.items():
             files[os.path.join(os.path.dirname(__file__), k)] = v
 

--- a/repo2docker_wholetale/r/start.sh
+++ b/repo2docker_wholetale/r/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env /bin/bash
 echo "www-frame-origin=${CSP_HOSTS:-none}" >> /etc/rstudio/rserver.conf
+echo "www-same-site=none" >> /etc/rstudio/rserver.conf
 echo "server-app-armor-enabled=0" >> /etc/rstudio/rserver.conf
 echo "session-default-working-dir=/WholeTale/workspace" >> /etc/rstudio/rsession.conf
 echo "session-default-new-project-dir=/WholeTale/workspace" >> /etc/rstudio/rsession.conf

--- a/repo2docker_wholetale/rocker.py
+++ b/repo2docker_wholetale/rocker.py
@@ -159,7 +159,7 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
             ),
         )
         rstudio_checksum = self.wt_env.get(
-            "WT_RSTUDIO_MD5", "e9764a5246bccc5ff9e39b62aea148ff"
+            "WT_RSTUDIO_MD5", "1d2bbd588f9a3ac00580939d4812a7d1"
         )
 
         scripts = [

--- a/repo2docker_wholetale/rocker.py
+++ b/repo2docker_wholetale/rocker.py
@@ -149,7 +149,7 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
             "WT_RSTUDIO_URL",
             (
                 "https://github.com/whole-tale/rstudio/releases/download/"
-                "v1.2.679-wt/rstudio-server-1.2.679-debian9-x86_64.deb"
+                "v1.4.1106-wt/rstudio-server-1.4.1106-bionic-amd64.deb"
             ),
         )
         rstudio_checksum = self.wt_env.get(
@@ -171,7 +171,8 @@ class RockerWTStackBuildPack(WholeTaleBuildPack):
                 curl --silent --location --fail {rstudio_url} > /tmp/rstudio.deb && \
                 echo '{rstudio_checksum} /tmp/rstudio.deb' | md5sum -c - && \
                 dpkg -i /tmp/rstudio.deb && \
-                rm /tmp/rstudio.deb
+                rm /tmp/rstudio.deb && \
+                chown rstudio:rstudio /var/lib/rstudio-server/rstudio.sqlite
                 """.format(
                     rstudio_url=rstudio_url, rstudio_checksum=rstudio_checksum
                 ),

--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -15,6 +15,7 @@ from repo2docker.buildpacks.r import RBuildPack
 
 class WholeTaleBuildPack(BuildPack):
 
+    major_pythons = {"2": "2.7", "3": "3.8"}
     _wt_env = None
 
     def binder_path(self, path):
@@ -136,6 +137,8 @@ class WholeTaleBuildPack(BuildPack):
 
 
 class WholeTaleRBuildPack(RBuildPack):
+
+    major_pythons = {"2": "2.7", "3": "3.8"}
 
     def binder_path(self, path):
         """


### PR DESCRIPTION
Fixes https://github.com/whole-tale/whole-tale/issues/108 (at least RStudio and Jupyter part, I haven't tried openrefine and matlab yet).

### How to test
1. Build local r2d_wt (or use xarthisius/repo2docker_wholetale:rsamesite)
1. Ensure that you're running latest girder + you've set "core.secure_cookie" to `true`.
2. Create a tale with  `"config.csp"` equal to: `"frame-ancestors 'self' https://dashboard.local.wholetale.org https://your.testsite"`
3. Run the Tale.
4. Using your `https://your.testsite` embed Instance url in an iframe.
5. Check all Images running jupyter and R. 

In the latest deploy-dev change "dev_images.json" in https://github.com/whole-tale/deploy-dev/blob/master/setup_girder.py#L153 to "stage_images.json" to quickly get a bunch of different environments.