### PR TITLE
Add xfce4-panel for dock/taskbar

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -147,6 +147,44 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 > ${HOME}/Desktop/Firefox.desktop && \
                 chmod +x ${HOME}/Desktop/*.desktop
                 """,
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                mkdir -p ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/ && \
+                printf "<?xml version='1.0' encoding='UTF-8'?> \
+                <channel name='xfce4-panel' version='1.0'> \
+                  <property name='configver' type='int' value='2'/> \
+                  <property name='panels' type='array'> \
+                    <value type='int' value='1'/> \
+                    <property name='panel-1' type='empty'> \
+                      <property name='position' type='string' value='p=8;x=720;y=750'/> \
+                      <property name='length' type='uint' value='100'/> \
+                      <property name='position-locked' type='bool' value='false'/> \
+                      <property name='size' type='uint' value='36'/> \
+                      <property name='plugin-ids' type='array'> \
+                        <value type='int' value='1'/> \
+                        <value type='int' value='3'/> \
+                        <value type='int' value='15'/> \
+                        <value type='int' value='6'/> \
+                      </property> \
+                      <property name='disable-struts' type='bool' value='false'/> \
+                      <property name='nrows' type='uint' value='1'/> \
+                      <property name='length-adjust' type='bool' value='true'/> \
+                    </property> \
+                  </property> \
+                  <property name='plugins' type='empty'> \
+                    <property name='plugin-1' type='string' value='applicationsmenu'/> \
+                    <property name='plugin-3' type='string' value='tasklist'/> \
+                    <property name='plugin-15' type='string' value='separator'> \
+                      <property name='expand' type='bool' value='true'/> \
+                      <property name='style' type='uint' value='0'/> \
+                    </property> \
+                    <property name='plugin-6' type='string' value='systray'/> \
+                  </property> \
+                </channel>\n" \
+                > ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+                """,
             )
         ]
 
@@ -271,4 +309,6 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
             'firefox',
             'mousepad',
             'xfce4',
+            'xfce4-goodies',
+            'xfce4-panel'
         }.union(super().get_base_packages())

--- a/repo2docker_wholetale/stata.py
+++ b/repo2docker_wholetale/stata.py
@@ -123,6 +123,44 @@ class StataWTStackBuildPack(JupyterWTStackBuildPack):
                 """,
             ),
             (
+                "${NB_USER}",
+                r"""
+                mkdir -p ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/ && \
+                printf "<?xml version='1.0' encoding='UTF-8'?> \
+                <channel name='xfce4-panel' version='1.0'> \
+                  <property name='configver' type='int' value='2'/> \
+                  <property name='panels' type='array'> \
+                    <value type='int' value='1'/> \
+                    <property name='panel-1' type='empty'> \
+                      <property name='position' type='string' value='p=8;x=720;y=750'/> \
+                      <property name='length' type='uint' value='100'/> \
+                      <property name='position-locked' type='bool' value='false'/> \
+                      <property name='size' type='uint' value='36'/> \
+                      <property name='plugin-ids' type='array'> \
+                        <value type='int' value='1'/> \
+                        <value type='int' value='3'/> \
+                        <value type='int' value='15'/> \
+                        <value type='int' value='6'/> \
+                      </property> \
+                      <property name='disable-struts' type='bool' value='false'/> \
+                      <property name='nrows' type='uint' value='1'/> \
+                      <property name='length-adjust' type='bool' value='true'/> \
+                    </property> \
+                  </property> \
+                  <property name='plugins' type='empty'> \
+                    <property name='plugin-1' type='string' value='applicationsmenu'/> \
+                    <property name='plugin-3' type='string' value='tasklist'/> \
+                    <property name='plugin-15' type='string' value='separator'> \
+                      <property name='expand' type='bool' value='true'/> \
+                      <property name='style' type='uint' value='0'/> \
+                    </property> \
+                    <property name='plugin-6' type='string' value='systray'/> \
+                  </property> \
+                </channel>\n" \
+                > ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+                """,
+            ),
+            (
                 "root",
                 r"""
                 mkdir -p /usr/local/stata/ado/plus && \
@@ -189,6 +227,8 @@ class StataWTStackBuildPack(JupyterWTStackBuildPack):
             'firefox',
             'mousepad',
             'xfce4',
+            'xfce4-goodies',
+            'xfce4-panel',
             'xfonts-base',
             'xvfb',
             'xxd',


### PR DESCRIPTION
**Problem:**
Per https://github.com/whole-tale/whole-tale/issues/110

* "it was also hard to scroll/see the results in the Stata console. Like the very bottom of the Stata window was cutoff and I could not view it. " (2)
* "The bottom of the Stata window/console is cut off in the WT window, so its difficult to scroll up/down to see the results. It's also a problem when the code stalls at some point -- you can't tell if its due to and error that stopped the code, or just a command that takes a while to execute. " (5)
* "Another problem was when I one wanted to minimize a window, I wasn't able maximize it again. In other words, minimizing was like closing a window....Not being able to find minimized windows was a bit annoying. Fixing that would be helpful"
(7)

**Approach**
Add and configure `xfce4-panel` in the STATA and MATLAB Xpra environments

<img width="605" alt="image" src="https://user-images.githubusercontent.com/4334350/155739926-cec5d531-1781-47ef-91fd-d6de7cddc067.png">

**To Test**
* Create and start a STATA/MATLAB tale
* Note that a dock/taskbar appears at the bottom of the screen
* Start STATA or MATLAB and confirm that minimizing/maximizing the window works


