### PR TITLE
Last buildscript entry needs to run as root for toolboxes to work

### DIFF
--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -102,13 +102,6 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                 """,
             ),
             (
-                "root",
-                r"""
-                DEBIAN_FRONTEND=noninteractive apt-get install -y  matlab-support && \
-                chown -R ${NB_USER}:${NB_USER} ${HOME}/.matlab
-                """,
-            ),
-            (
                 "${NB_USER}",
                 r"""
                 mkdir -p ${HOME}/Desktop && \
@@ -184,6 +177,13 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
                   </property> \
                 </channel>\n" \
                 > ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+                """,
+            ),
+            (
+                "root",
+                r"""
+                DEBIAN_FRONTEND=noninteractive apt-get install -y  matlab-support && \
+                chown -R ${NB_USER}:${NB_USER} ${HOME}/.matlab
                 """,
             )
         ]


### PR DESCRIPTION
When `get_preassemble_scripts` is called in r2d, it assumes that the last user was root (even if it wasn't). https://github.com/whole-tale/repo2docker/blob/master/repo2docker/buildpacks/base.py#L497-L498

Without changing r2d behavior for the `toolboxes.txt` implementation to work, the last entry in `get_build_scripts` needs to run as root. This PR does that.

**To Test**
* Build this image or use `craigwilis/repo2docker_wholetale:buildscript` (already running on .test)
* Create a tale using https://github.com/whole-tale/matlab-example
* Run the tale and confirm image build succeeds. It should contain the following:

```
#48 4.695 (Mar 16, 2022 14:56:38) User Name: root
#48 4.696 (Mar 16, 2022 14:56:38) Current Directory: /matlab-install
#48 4.696 (Mar 16, 2022 14:56:38) Installer build number: 9.9.0.1467703
#48 4.698 (Mar 16, 2022 14:56:38) Input arguments:
#48 4.706 (Mar 16, 2022 14:56:38) licensepath: /matlab-install/network.lic
#48 4.707 (Mar 16, 2022 14:56:38) mode: silent
#48 4.708 (Mar 16, 2022 14:56:38) root: /matlab-install
#48 4.708 (Mar 16, 2022 14:56:38) product.optimization_toolbox: true
#48 4.708 (Mar 16, 2022 14:56:38) outputfile: /dev/stdout
#48 4.709 (Mar 16, 2022 14:56:38) product.econometrics_toolbox: true
#48 4.709 (Mar 16, 2022 14:56:38) destinationfolder: /usr/local/MATLAB/R2020b
#48 4.710 (Mar 16, 2022 14:56:38) agreetolicense: yes
#48 4.710 (Mar 16, 2022 14:56:38) product.statistics_and_machine_learning_toolbox: true
#48 4.710 (Mar 16, 2022 14:56:38) flow: fikworkflow
#48 4.992 (Mar 16, 2022 14:56:39) Reading from /matlab-install/archives
#48 4.999 (Mar 16, 2022 14:56:39) Starting local product/component search in download directory
#48 5.000 (Mar 16, 2022 14:56:39) Searching for archives...
#48 5.001 (Mar 16, 2022 14:56:39) Reading /matlab-install/archives
#48 5.007 (Mar 16, 2022 14:56:39) Extracting /matlab-install/archives/platform_common.zip
#48 5.008 (Mar 16, 2022 14:56:39) Extracting /matlab-install/archives/platform_glnxa64.zip
#48 5.008 (Mar 16, 2022 14:56:39) Archive search complete.  2 total files found.
#48 9.116 (Mar 16, 2022 14:56:43) Finished reading from/matlab-install/archives
#48 9.126 (Mar 16, 2022 14:56:43) Completed local product/component search
#48 9.214 (Mar 16, 2022 14:56:43) License file path /matlab-install/network.lic
#48 12.43 (Mar 16, 2022 14:56:46) Confirm selections
#48 12.44 (Mar 16, 2022 14:56:46) Destination
#48 12.44 (Mar 16, 2022 14:56:46) /usr/local/MATLAB/R2020b/
#48 12.44 (Mar 16, 2022 14:56:46) Products
#48 12.44 (Mar 16, 2022 14:56:46) 3 of 95 products
#48 12.44 (Mar 16, 2022 14:56:46) 0.4 GB required
#48 12.44 (Mar 16, 2022 14:56:46)
#48 12.49 (Mar 16, 2022 14:56:46) Download thread pool size = 4
#48 12.80 (Mar 16, 2022 14:56:47) Installing Product: Econometrics Toolbox
#48 18.14 (Mar 16, 2022 14:56:52) Installing Product: Optimization Toolbox
#48 22.25 (Mar 16, 2022 14:56:56) Installing Product: Statistics and Machine Learning Toolbox
#48 47.60 (Mar 16, 2022 14:57:21) Exiting with status 0
#48 47.60 (Mar 16, 2022 14:57:21) End - Successful
#48 48.71 (Mar 16, 2022 14:57:21) End - Successful
#48 DONE 50.1s
```
