### PR TITLE
Port to latest upstream r2d

### DIFF
--- a/repo2docker_wholetale/dockercli.py
+++ b/repo2docker_wholetale/dockercli.py
@@ -1,0 +1,89 @@
+"""Docker container engine for repo2docker using docker-cli."""
+import os
+import subprocess
+import shutil
+import tarfile
+import tempfile
+
+from repo2docker.docker import DockerEngine
+
+
+class DockerCLIEngine(DockerEngine):
+    """Docker container engine using docker-cli, currently only for build()."""
+
+    def build(
+        self,
+        *,
+        buildargs=None,
+        cache_from=None,
+        container_limits=None,
+        tag="",
+        custom_context=False,
+        dockerfile="",
+        fileobj=None,
+        path="",
+        labels=None,
+        **kwargs,
+    ):
+        """Build docker container using docker-cli with BUILDKIT."""
+        build_cmd = "docker build --progress plain"
+
+        if tag is not None:
+            build_cmd = build_cmd + " --tag " + tag
+
+        if path:
+            os.chdir(path)
+
+        if dockerfile:
+            build_cmd = build_cmd + " -f " + dockerfile
+
+        tempdir = tempfile.mkdtemp()
+        if fileobj is not None:
+            tar = tarfile.open(fileobj=fileobj, mode="r")
+            tar.extractall(tempdir)
+            tar.close()
+            path = tempdir
+
+        if buildargs is not None:
+            for key, value in buildargs.items():
+                build_cmd = build_cmd + " --build-arg " + key + "=" + value
+
+        # TODO: Handle extra_build_kwargs?
+
+        if kwargs.get("forcerm"):
+            build_cmd = build_cmd + " --force-rm"
+
+        if kwargs.get("rm"):
+            build_cmd = build_cmd + " --rm"
+
+        if container_limits is not None:
+            if "memlimit" in container_limits:
+                build_cmd = build_cmd + " --memory " + container_limits["memlimit"]
+
+        if cache_from:
+            build_cmd = build_cmd + " --cache-from"
+            for cache in cache_from:
+                build_cmd = build_cmd + " " + cache
+
+        build_cmd = build_cmd + " " + path
+
+        with subprocess.Popen(
+            build_cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"},
+        ) as p:
+
+            while True:
+                line = p.stdout.readline()
+                if p.poll() is not None:
+                    break
+                yield {"stream": line}
+
+            rc = p.poll()
+            if rc != 0:
+                yield {"error": line}
+
+        shutil.rmtree(tempdir)

--- a/repo2docker_wholetale/matlab.py
+++ b/repo2docker_wholetale/matlab.py
@@ -51,7 +51,7 @@ class MatlabWTStackBuildPack(JupyterWTStackBuildPack):
         Return args to be set at build time. FILE_INSTALLATION_KEY is
         required only at build time.
         """
-        return super().get_build_args() + ["FILE_INSTALLATION_KEY"]
+        return super().get_build_args() | {"FILE_INSTALLATION_KEY": "some_key"}
 
     def get_build_scripts(self):
         """

--- a/repo2docker_wholetale/stata.py
+++ b/repo2docker_wholetale/stata.py
@@ -200,7 +200,7 @@ class StataWTStackBuildPack(JupyterWTStackBuildPack):
 
         STATA_LICENSE is required only at build time.
         """
-        return super().get_build_args() + ["STATA_LICENSE_ENCODED"]
+        return super().get_build_args() | {"STATA_LICENSE_ENCODED": "your_license"}
 
     def get_preassemble_script_files(self):
         files = super().get_preassemble_script_files()

--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -18,6 +18,9 @@ class WholeTaleBuildPack(BuildPack):
     major_pythons = {"2": "2.7", "3": "3.8"}
     _wt_env = None
 
+    def get_build_args(self):
+        return {}
+
     def binder_path(self, path):
         """
         Locate a build file in a default dir.
@@ -50,7 +53,6 @@ class WholeTaleBuildPack(BuildPack):
         )
         return files
 
-
     def get_build_scripts(self):
         return super().get_build_scripts() + [
             (
@@ -59,10 +61,9 @@ class WholeTaleBuildPack(BuildPack):
                 wget -O /usr/local/bin/reprozip https://github.com/cirss/reprozip-static/releases/download/v1.0.16-r1/reprozip-1.016-linux-x86-64-static \
                 && chmod a+x /usr/local/bin/reprozip \
                 && LC_ALL=POSIX reprozip usage_report --disable
-                """
+                """,
             )
         ]
-
 
     def apt_assemble_script(self):
         if os.path.exists(self.binder_path("apt.txt")):
@@ -135,6 +136,24 @@ class WholeTaleBuildPack(BuildPack):
 
         shutil.rmtree(tempdir, ignore_errors=True)
 
+    def build(
+        self,
+        client,
+        image_spec,
+        memory_limit,
+        build_args,
+        cache_from,
+        extra_build_kwargs,
+    ):
+        if build_args:
+            for k, v in self.get_build_args().items():
+                build_args.setdefault(k, v)
+        else:
+            build_args = self.get_build_args()
+        yield from super().build(
+            client, image_spec, memory_limit, build_args, cache_from, extra_build_kwargs
+        )
+
 
 class WholeTaleRBuildPack(RBuildPack):
 
@@ -150,6 +169,9 @@ class WholeTaleRBuildPack(RBuildPack):
             if os.path.exists(possible_config_dir):
                 return os.path.join(possible_config_dir, path)
         return path
+
+    def get_build_args(self):
+        return {}
 
     def set_checkpoint_date(self):
         if not self.checkpoint_date:
@@ -181,6 +203,24 @@ class WholeTaleRBuildPack(RBuildPack):
                 wget -O /usr/local/bin/reprozip https://github.com/cirss/reprozip-static/releases/download/v1.0.16-r1/reprozip-1.016-linux-x86-64-static \
                 && chmod a+x /usr/local/bin/reprozip \
                 && LC_ALL=POSIX reprozip usage_report --disable
-                """
+                """,
             )
         ]
+
+    def build(
+        self,
+        client,
+        image_spec,
+        memory_limit,
+        build_args,
+        cache_from,
+        extra_build_kwargs,
+    ):
+        if build_args:
+            for k, v in self.get_build_args().items():
+                build_args.setdefault(k, v)
+        else:
+            build_args = self.get_build_args()
+        yield from super().build(
+            client, image_spec, memory_limit, build_args, cache_from, extra_build_kwargs
+        )

--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -156,8 +156,7 @@ class WholeTaleRBuildPack(RBuildPack):
             # no R snapshot date set through runtime.txt so set
             # to a reasonable default -- the last month of the previous
             # quarter
-            quarter = self.mran_date(datetime.date.today())
-            self._checkpoint_date = self._get_latest_working_mran_date(quarter, 3)
+            self._checkpoint_date = self.mran_date(datetime.date.today())
             self._runtime = "r-{}".format(str(self._checkpoint_date))
 
     def detect(self, buildpack=None):

--- a/setup.py
+++ b/setup.py
@@ -5,44 +5,49 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = []
 
-setup_requirements = ['pytest-runner']
+setup_requirements = ["pytest-runner"]
 
-test_requirements = ['pytest']
+test_requirements = ["pytest"]
 
 setup(
     author="Kacper Kowalik",
-    author_email='xarthisius.kk@gmail.com',
+    author_email="xarthisius.kk@gmail.com",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     description="repo2docker plugin for WholeTale project.",
     install_requires=requirements,
     license="BSD license",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='repo2docker_wholetale',
-    name='repo2docker_wholetale',
+    keywords="repo2docker_wholetale",
+    name="repo2docker_wholetale",
     packages=find_packages(),
     setup_requires=setup_requirements,
-    test_suite='tests',
+    test_suite="tests",
     tests_require=test_requirements,
     url='https://github.com/whole-tale/repo2docker_wholetale',
     version='1.1.post1',
     zip_safe=False,
+    entry_points={
+        "repo2docker.engines": [
+            "dockercli = repo2docker_wholetale.dockercli:DockerCLIEngine"
+        ]
+    },
 )


### PR DESCRIPTION
In theory this PR will allow us to run almost vanilla repo2docker (only change that remains is setting mran to last quarter rather than "3 days ago"). You can test this by building it with `xarthisius/repo2docker:latest` (which is based on https://github.com/whole-tale/repo2docker/tree/updated_from_main)

NOTE: You need to patch `gwvolman` to use our new engine:

```diff
diff --git a/gwvolman/build_utils.py b/gwvolman/build_utils.py
index 24364b1..2e1a045 100644
--- a/gwvolman/build_utils.py
+++ b/gwvolman/build_utils.py
@@ -167,6 +167,7 @@ class ImageBuilder:
         target_repo_dir = os.path.join(self.container_config.target_mount, "workspace")
         r2d_cmd = (
             "jupyter-repo2docker "
+            "--engine dockercli "
             "--config='/wholetale/repo2docker_config.py' "
             f"--target-repo-dir='{target_repo_dir}' "
             f"--user-id=1000 --user-name={self.container_config.container_user} "
```