### PR TITLE
Always set python from environment.yml if present

### DIFF
--- a/repo2docker_wholetale/wholetale.py
+++ b/repo2docker_wholetale/wholetale.py
@@ -11,6 +11,7 @@ import tempfile
 
 from repo2docker.buildpacks.base import BuildPack
 from repo2docker.buildpacks.r import RBuildPack
+from repo2docker.buildpacks.python import PythonBuildPack
 
 
 class WholeTaleBuildPack(BuildPack):
@@ -160,6 +161,14 @@ class WholeTaleRBuildPack(RBuildPack):
 
     def get_build_args(self):
         return {}
+
+    @property
+    def python_version(self):
+        """If environment.yaml is present, use PythonBuildPack's parent (conda) python_version"""
+        if self.environment_yaml:
+            return super(PythonBuildPack, self).python_version
+        else:
+            return super(RBuildPack, self).python_version
 
     def set_checkpoint_date(self):
         if not self.checkpoint_date:


### PR DESCRIPTION
Allow environment.yml to take precedence over runtime.txt when selecting runtime. Fixes #50 Question is what's gonna happen if both are present and is that everything that has to be overridden like that?

### How test?

1. Deploy with gwvolman using `xarthisius/repo2docker_wholetale:issue50` 
r2d image.
1. Import a Tale from git: https://github.com/MarkusKonk/CompEnv-Ex2@branch-b
3. Select Jupyter Lab image
4. Run the tale. It should build fine.

